### PR TITLE
Render method now resolves to object with an unmount

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -127,7 +127,7 @@ export default class QdtComponent extends React.Component {
     this.qdtInstance = qdtComponents.render(type, props, this.node);
   }
 
-  componentDidUnmount() {
+  componentWillUnmount() {
     this.qdtInstance.then(({ unmount }) => unmount())
   }
 

--- a/readme.md
+++ b/readme.md
@@ -82,9 +82,13 @@ export class QdtComponent implements OnInit {
   constructor(private elementRef: ElementRef) { }
 
   ngOnInit() {
-    QdtComponent.qdtComponents.render(this.type, this.props, this.elementRef.nativeElement);
+    this.qdtInstance = QdtComponent.qdtComponents.render(this.type, this.props, this.elementRef.nativeElement);
   }
-  
+
+  ngOnDestroy() {
+    this.qdtInstance.then(({ umount }) => unmount())
+  }
+
 }
 ```
 
@@ -120,7 +124,11 @@ export default class QdtComponent extends React.Component {
   }
   componentDidMount() {
     const { type, props } = this.props;
-    qdtComponents.render(type, props, this.node);
+    this.qdtInstance = qdtComponents.render(type, props, this.node);
+  }
+
+  componentDidUnmount() {
+    this.qdtInstance.then(({ unmount }) => unmount())
   }
 
   render() {

--- a/src/QdtComponents.jsx
+++ b/src/QdtComponents.jsx
@@ -33,7 +33,6 @@ const QdtComponents = class {
   }
 
   render = async (type, props, element) => new Promise((resolve, reject) => {
-
     try {
       const { qAppPromise, qDocPromise } = this;
       const Component = components[type];

--- a/src/QdtComponents.jsx
+++ b/src/QdtComponents.jsx
@@ -36,17 +36,16 @@ const QdtComponents = class {
     try {
       const { qAppPromise, qDocPromise } = this;
       const Component = components[type];
-      ReactDOM.render(
+      const node = ReactDOM.render(
         <Component
           {...props}
           qAppPromise={qAppPromise}
           qDocPromise={qDocPromise}
-          ref={node => resolve(node)}
         />,
         element,
       );
       const unmount = QdtComponents.createUnmount(element);
-      resolve({ unmount });
+      resolve({ unmount, node });
     } catch (error) {
       reject(error);
     }

--- a/src/QdtComponents.jsx
+++ b/src/QdtComponents.jsx
@@ -23,6 +23,8 @@ const QdtComponents = class {
     settings,
   };
 
+  static createUnmount = element => () => ReactDOM.unmountComponentAtNode(element);
+
   constructor(config = {}, connections = { vizApi: true, engineApi: true, useUniqueSessionID: null }) {
     const myConfig = config;
     myConfig.identity = connections.useUniqueSessionID ? connections.useUniqueSessionID : utility.Uid(16);
@@ -31,6 +33,7 @@ const QdtComponents = class {
   }
 
   render = async (type, props, element) => new Promise((resolve, reject) => {
+
     try {
       const { qAppPromise, qDocPromise } = this;
       const Component = components[type];
@@ -43,6 +46,8 @@ const QdtComponents = class {
         />,
         element,
       );
+      const unmount = QdtComponents.createUnmount(element);
+      resolve({ unmount });
     } catch (error) {
       reject(error);
     }


### PR DESCRIPTION
Hi, I really like the library. My colleagues and I have started using it for a project, but I noticed what I think is small mistake. 

The QDT `render` method calls `ReactDOM.render` to render the component to an DOM node, but nothing ever calls `ReactDOM.unmountComponentAtNode`, and there is no public API for doing so. All the components have the logic for unmounts implemented, but I don't believe any of their unmounts get called. This is evidenced by the fact that references to them remain within react dev tools even after any wrapper component gets destroyed. This represents a potential memory leak on the client, and an unnecessary allocation of resources on the server.

If you happen to be using React anyway you can call `unmountComponentAtNode` yourself on the element, but as the library bundles its own version of React (subject of another upcoming PR), there is no guarantee that it will be the same version of `ReactDOM`. The result in most cases are warnings about using multiple versions of React, and in future this could lead to breakages as React internals change over time.

This PR fixes the problem by having the promise for `render` resolve to an object with a `unmount` function. I have also taken to updating the documented examples for Angular and React, but I'm uncertain about the Angular one as I don't have much in the way of Angular experience.