### PR TITLE
Removed unncessary modification to the window object qApp function

### DIFF
--- a/src/qApp.js
+++ b/src/qApp.js
@@ -1,3 +1,5 @@
+let qlik;
+
 const loadCapabilityApis = async (config) => {
   try {
     const capabilityApisJS = document.createElement('script');
@@ -39,13 +41,13 @@ const qApp = async (config) => {
       },
     });
     return new Promise((resolve) => {
-      if (window.qlik) {
-        const app = window.qlik.openApp(config.appId, { ...config, isSecure: config.secure, prefix });
+      if (qlik) {
+        const app = qlik.openApp(config.appId, { ...config, isSecure: config.secure, prefix });
         resolve(app);
       } else {
-        window.require(['js/qlik'], (qlik) => {
-          window.qlik = qlik;
-          const app = window.qlik.openApp(config.appId, { ...config, isSecure: config.secure, prefix });
+        window.require(['js/qlik'], (q) => {
+          qlik = q;
+          const app = qlik.openApp(config.appId, { ...config, isSecure: config.secure, prefix });
           resolve(app);
         });
       }

--- a/src/qApp.js
+++ b/src/qApp.js
@@ -1,7 +1,12 @@
 let qlik;
+let capabilityApisPromise;
 
 const loadCapabilityApis = async (config) => {
   try {
+    if (capabilityApisPromise) {
+      await capabilityApisPromise;
+      return;
+    }
     const capabilityApisJS = document.createElement('script');
     const prefix = (config.prefix !== '') ? `/${config.prefix}` : '';
     capabilityApisJS.src = `${(config.secure ? 'https://' : 'http://') + config.host + (config.port ? `:${config.port}` : '') + prefix}/resources/assets/external/requirejs/require.js`;
@@ -17,7 +22,10 @@ const loadCapabilityApis = async (config) => {
     capabilityApisCSS.loaded = new Promise((resolve) => {
       capabilityApisCSS.onload = () => { resolve(); };
     });
-    await Promise.all([capabilityApisJS.loaded, capabilityApisCSS.loaded]);
+
+    capabilityApisPromise = Promise.all([capabilityApisJS.loaded, capabilityApisCSS.loaded]);
+
+    await capabilityApisPromise;
   } catch (error) {
     throw new Error(error);
   }


### PR DESCRIPTION
This PR removed the unnecessary modification to the window object to store a reference to the qlik object. Instead, the qlik object is stored within the module scope, and so doesn't pollute global scope.